### PR TITLE
camera: Make camera_device_open/close static

### DIFF
--- a/camera/CameraWrapper.cpp
+++ b/camera/CameraWrapper.cpp
@@ -455,7 +455,7 @@ int camera_dump(struct camera_device * device, int fd)
     return VENDOR_CALL(device, dump, fd);
 }
 
-int camera_device_close(hw_device_t* device)
+static int camera_device_close(hw_device_t* device)
 {
     int ret = 0;
     wrapper_camera_device_t *wrapper_dev = NULL;
@@ -494,7 +494,7 @@ done:
  * so this function will always only be called once per camera instance
  */
 
-int camera_device_open(const hw_module_t* module, const char* name,
+static int camera_device_open(const hw_module_t* module, const char* name,
                 hw_device_t** device)
 {
     int rv = 0;


### PR DESCRIPTION
- This fixes an issue in Google Camera
  To Replicate the issue:
  1. Take a Photo
  2. Try to Switch Cameras
  3. Watch it Burn
- Camera2 still needs fixing

Change-Id: Ifc6c5b3cbd8db96aafa409c01b0825435b9ee9dc
Signed-off-by: Paul Keith javelinanddart@gmail.com
(cherry picked from commit 08b15b4b58cc128a604cd0d2ec4b28da307ec8e1)
